### PR TITLE
Add support for MATE and remove ambiguity in variable names

### DIFF
--- a/ipfs-screen.sh
+++ b/ipfs-screen.sh
@@ -1,4 +1,9 @@
 #! /bin/bash
+if ! command -v ipfs &> /dev/null; then
+    echo "IPFS is not available, install from: https://ipfs.io/"
+    exit 1
+fi
+
 echo "testing" 1>> "$HOME/.ipfs-screen/ipfs-add.log"
 
 FPATH="ipfs-screen.jpg"
@@ -6,7 +11,7 @@ FPATH="ipfs-screen.jpg"
 if command -v gnome-screenshot &> /dev/null; then
     gnome-screenshot -a -f "$HOME/.ipfs-screen/$FPATH"
 elif command -v mate-screenshot &> /dev/null; then
-    mate-screenshot -a -f "$HOME/.ipfs-screen/$FPATH"
+    mate-screenshot -a "$HOME/.ipfs-screen/$FPATH"
 else
     echo "OS is not supported yet"
     exit 1

--- a/ipfs-screen.sh
+++ b/ipfs-screen.sh
@@ -2,7 +2,14 @@
 echo "testing" >> ~/.ipfs-screen/ipfs-add.log
 file=ipfs-screen.jpg
 
-gnome-screenshot -a -f ~/.ipfs-screen/$file
+if command -v gnome-screenshot &> /dev/null; then
+    gnome-screenshot -a -f ~/.ipfs-screen/$file
+elif command -v mate-screenshot &> /dev/null; then
+    mate-screenshot -a -f ~/.ipfs-screen/$file
+else
+    echo "OS is not supported yet"
+    exit 1
+fi
 
 hash_log=$(ipfs add ~/.ipfs-screen/$file)
 

--- a/ipfs-screen.sh
+++ b/ipfs-screen.sh
@@ -1,21 +1,21 @@
 #! /bin/bash
-echo "testing" >> ~/.ipfs-screen/ipfs-add.log
-file=ipfs-screen.jpg
+echo "testing" 1>> "$HOME/.ipfs-screen/ipfs-add.log"
+
+FPATH="ipfs-screen.jpg"
 
 if command -v gnome-screenshot &> /dev/null; then
-    gnome-screenshot -a -f ~/.ipfs-screen/$file
+    gnome-screenshot -a -f "$HOME/.ipfs-screen/$FPATH"
 elif command -v mate-screenshot &> /dev/null; then
-    mate-screenshot -a -f ~/.ipfs-screen/$file
+    mate-screenshot -a -f "$HOME/.ipfs-screen/$FPATH"
 else
     echo "OS is not supported yet"
     exit 1
 fi
 
-hash_log=$(ipfs add ~/.ipfs-screen/$file)
+hash_log=$(ipfs add "$HOME/.ipfs-screen/$FPATH")
 
-echo $hash_log >> ~/.ipfs-screen/ipfs-add.log
+echo "$hash_log" 1>> "$HOME/.ipfs-screen/ipfs-add.log"
 
+HASH=$(echo "$hash_log" | awk '{ print $2; }')
 
-hash=$(echo $hash_log | awk '{ print $2; }')
-
-echo "https://ipfs.io/ipfs/$hash" | xclip -selection clipboard
+echo "https://ipfs.io/ipfs/$HASH" | xclip -selection clipboard


### PR DESCRIPTION
This pull-request adds support to use the default screenshot tool available in the MATE Linux desktop environment. Additionally, Unix like systems have a command named "file" which prints the mimetype of the resource that is being read, using a variable in the shell script named the same way causes collisions. Using `$HOME` is less ambiguous than using the shorthand `~` character. Also, a new conditional is going to be added to check if the IPFS tool is actually available, note that _"available"_ is different than _"installed"_, the user might have forgotten to expose the binary via `$PATH`.