### PR TITLE
Use a reasonable filename instead of just 'ipfs-screen.png'

### DIFF
--- a/ipfs-screen.sh
+++ b/ipfs-screen.sh
@@ -2,10 +2,12 @@
 mkdir -p ~/.ipfs-screen/
 echo "testing" >> ~/.ipfs-screen/ipfs-add.log
 file=$(date +"%Y-%m-%d-%T-screenshot")
+clipboard_command="xclip -selection clipboard"
 
 platform=`uname`
 if [[ "$platform" == "Darwin" ]]; then
   screencapture -t jpg -i ~/.ipfs-screen/$file
+  clipboard_command="pbcopy"
 else
   gnome-screenshot -a -f ~/.ipfs-screen/$file
 fi
@@ -16,10 +18,4 @@ echo $hash_log >> ~/.ipfs-screen/ipfs-add.log
 
 hash=$(echo $hash_log | awk '{ print $2; }')
 
-clipboard_command="xclip -selection clipboard"
-
-if [[ "$platform" == "Darwin" ]]; then
-  clipboard_command="pbcopy"
-fi
-
-echo -n "https://ipfs.io/ipfs/$hash" | `$clipboard_command`
+echo "https://ipfs.io/ipfs/$hash" | $clipboard_command

--- a/ipfs-screen.sh
+++ b/ipfs-screen.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 mkdir -p ~/.ipfs-screen/
 echo "testing" >> ~/.ipfs-screen/ipfs-add.log
-file=ipfs-screen.png
+file=$(date +"%Y-%m-%d-%T-screenshot")
 
 platform=`uname`
 if [[ "$platform" == "Darwin" ]]; then


### PR DESCRIPTION
It would be better (in my opinion) if the filename had a bit more information other than just 'ipfs-screen.png'. This pull-request makes it the same format as scrot, which is the current date, producing filenames like '2016-10-25-09:30:59-screenshot.png'.

In the future it could be nice to be able to specify the latter it 'screenshot' to provide some context.
